### PR TITLE
Change u32 to u8 inside register test

### DIFF
--- a/unit_test/register_test_suite.c
+++ b/unit_test/register_test_suite.c
@@ -81,7 +81,7 @@ void test_register_InvalidRegState_REG_Write_ErrReturned()
     REG_MemoryInit(&memory);
 
     /* Array of wrong (address, wrong state) pairs */
-    const u32 wrongAddrStatePair[][5] =
+    const u8 wrongAddrStatePair[][5] =
     {
         {REG_AddrDecodeMode, REG_DecodeModeDigit0To3 + 1},
         {REG_AddrIntensity, REG_Intensity31_32 + 1},


### PR DESCRIPTION
This closes issue #12.
Change u32 to u8 inside test_register_InvalidRegState_REG_Write_ErrReturned()